### PR TITLE
Made webroot argument optional on load command (defaults to CWD).

### DIFF
--- a/src/SSPak.php
+++ b/src/SSPak.php
@@ -27,7 +27,7 @@ class SSPak {
 			),
 			"load" => array(
 				"description" => "Load an .sspak file into a SilverStripe site. Does not backup - be careful!",
-				"unnamedArgs" => array("sspak file", "webroot"),
+				"unnamedArgs" => array("sspak file", "[webroot]"),
 				"namedFlags" => array("drop-db"),
 				"method" => "load",
 			),
@@ -280,12 +280,12 @@ class SSPak {
 	function load($args) {
 		$executor = $this->executor;
 
-		$args->requireUnnamed(array('source sspak file', 'dest webroot'));
+		$args->requireUnnamed(array('source sspak file'));
 
 		// Set-up
 		$file = $args->unnamed(0);
 		$sspak = new SSPakFile($file, $executor);
-		$webroot = new Webroot($args->unnamed(1), $executor);
+		$webroot = new Webroot(($args->unnamed(1) ?: '.'), $executor);
 		$webroot->setSudo($args->sudo('to'));
 		$pakParts = $args->pakParts();
 


### PR DESCRIPTION
My usage pattern in SSPak involves frequently loading .sspak files into new local copies of websites. I always perform this operation from within the root directory of the site.

This patch streamlines the process slightly by allowing users to omit the second parameter if they are applying the file to their current working directory.