### PR TITLE
FIX Always import to the correct DB

### DIFF
--- a/src/Webroot.php
+++ b/src/Webroot.php
@@ -108,7 +108,7 @@ class Webroot extends FilesystemEntity {
 		$this->exec("echo '$dbCommand' | mysql $usernameArg $passwordArg $hostArg $portArg");
 
 		$stream = $sspak->readStreamForFile('database.sql.gz');
-		$this->exec("gunzip -c | mysql --default-character-set=utf8 $usernameArg $passwordArg $hostArg $portArg $databaseArg", array('inputStream' => $stream));
+		$this->exec("gunzip -c | sed '/^CREATE DATABASE/d;/^USE/d' | mysql --default-character-set=utf8 $usernameArg $passwordArg $hostArg $portArg $databaseArg", array('inputStream' => $stream));
 		fclose($stream);
 		return true;
 	}


### PR DESCRIPTION
This fixes an issue where a sql dump has a `USE` or `CREATE` statement.

sspak won't handle that well and will end up creating a new DB instead of importing into the target DB.

This change strips out lines starting with `USE` or `CREATE` to ensure that the intended DB is used.