### PR TITLE
NEW: CSV save/load commands for sspak

### DIFF
--- a/bin/sspak
+++ b/bin/sspak
@@ -11,6 +11,8 @@ require_once(PACKAGE_ROOT . 'src/FilesystemEntity.php');
 require_once(PACKAGE_ROOT . 'src/SSPakFile.php');
 require_once(PACKAGE_ROOT . 'src/Webroot.php');
 
+require_once(PACKAGE_ROOT . 'vendor/autoload.php');
+
 $argObj = new Args($_SERVER['argv']);
 /*
 // Special case for self-extracting sspaks

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,18 @@
 {
-     "name": "silverstripe/sspak",
-     "description": "CLI tool for saving & loading data in SilverStripe installations",
-     "license": "BSD-3-Clause",
-     "authors": [
-         {
-             "name": "Sam Minnee",
-             "email": "sam@silverstripe.com"
-         }
-     ],
-     "autoload": {
-     	"classmap": [ "src/" ]
-     },
-     "require": {},
-     "require-dev": {
-         "phpunit/phpunit": "^3.7"
-     }
- }
+	"name": "silverstripe/sspak",
+	"description": "CLI tool for saving & loading data in SilverStripe installations",
+	"license": "BSD-3-Clause",
+	"authors": [
+		{
+			"name": "Sam Minnee",
+			"email": "sam@silverstripe.com"
+		}
+	],
+	"autoload": {
+		"classmap": [ "src/" ]
+	},
+	"require": {},
+	"require-dev": {
+		"phpunit/phpunit": "^3.7"
+	}
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4d3cf135125c8dc81d955e67cb7fd3c4",
+    "hash": "e8f637aaa0931f73f8b15e558734a4dc",
     "content-hash": "e649c0660b9ca5d326f6a0e52e30031e",
     "packages": [],
     "packages-dev": [

--- a/src/DataExtractor/CsvTableReader.php
+++ b/src/DataExtractor/CsvTableReader.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SilverStripe\SsPak\DataExtractor;
+
+class CsvTableReader implements TableReader
+{
+
+	private $filename;
+	private $handle;
+	private $columns;
+
+	function __construct($filename) {
+		$this->filename = $filename;
+	}
+
+	function getColumns() {
+		if (!$this->columns) {
+			$this->initColumns();
+		}
+		return $this->columns;
+	}
+
+	function getIterator() {
+		$this->columns = null;
+		$this->initColumns();
+
+		while(($row = $this->getRow()) !== false) {
+			yield $this->mapToColumns($row);
+		}
+
+		$this->close();
+	}
+
+	private function mapToColumns($row) {
+		$record = [];
+		foreach($row as $i => $value)
+		{
+			if(isset($this->columns[$i])) {
+				$record[$this->columns[$i]] = $value;
+			} else {
+				throw new \LogicException("Row contains invalid column #$i\n" . var_export($row, true));
+			}
+		}
+		return $record;
+	}
+
+	private function initColumns() {
+		$this->open();
+		$this->columns = $this->getRow();
+	}
+
+	private function getRow() {
+		return fgetcsv($this->handle);
+	}
+
+	private function open() {
+		if ($this->handle) {
+			fclose($this->handle);
+			$this->handle = null;
+		}
+		$this->handle = fopen($this->filename, 'r');
+	}
+
+	private function close() {
+		if ($this->handle) {
+			fclose($this->handle);
+			$this->handle = null;
+		}
+	}
+}

--- a/src/DataExtractor/CsvTableWriter.php
+++ b/src/DataExtractor/CsvTableWriter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SilverStripe\SsPak\DataExtractor;
+
+class CsvTableWriter implements TableWriter
+{
+
+	private $filename;
+	private $handle;
+	private $columns;
+
+	function __construct($filename) {
+		$this->filename = $filename;
+	}
+
+	function start($columns) {
+		$this->open();
+		$this->putRow($columns);
+		$this->columns = $columns;
+	}
+
+	function finish() {
+		$this->close();
+	}
+
+	function writeRecord($record) {
+		if (!$this->columns) {
+			$this->start(array_keys($record));
+		}
+
+		$this->putRow($this->mapFromColumns($record));
+	}
+
+	private function mapFromColumns($record) {
+		$row = [];
+		foreach($this->columns as $i => $column)
+		{
+			$row[$i] = isset($record[$column]) ? $record[$column] : null;
+		}
+		return $row;
+	}
+
+	private function putRow($row) {
+		return fputcsv($this->handle, $row);
+	}
+
+	private function open() {
+		if ($this->handle) {
+			fclose($this->handle);
+			$this->handle = null;
+		}
+		$this->handle = fopen($this->filename, 'w');
+		if (!$this->handle) {
+			throw new \LogicException("Can't open $this->filename for writing.");
+		}
+	}
+
+	private function close() {
+		if ($this->handle) {
+			fclose($this->handle);
+			$this->handle = null;
+		}
+	}
+}

--- a/src/DataExtractor/DatabaseConnector.php
+++ b/src/DataExtractor/DatabaseConnector.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace SilverStripe\SsPak\DataExtractor;
+
+use DB;
+
+/**
+ * Connects to the SilverStripe Database object of a given SilverStripe project,
+ * in order to bulk save/load data
+ */
+class DatabaseConnector
+{
+
+	private $basePath;
+	private $isConnected = false;
+
+	function __construct($basePath) {
+		$this->basePath = $basePath;
+	}
+
+	function connect() {
+		if ($this->isConnected) {
+			return;
+		}
+
+		$this->isConnected = true;
+
+		// Necessary for SilverStripe's _ss_environment.php loader to work
+		$_SERVER['SCRIPT_FILENAME'] = $this->basePath . '/dummy.php';
+
+		global $databaseConfig;
+
+		// require composers autoloader
+		if (file_exists($this->basePath . '/vendor/autoload.php')) {
+			require_once $this->basePath . '/vendor/autoload.php';
+		}
+
+		if (file_exists($this->basePath . '/framework/core/Core.php')) {
+			require_once($this->basePath . '/framework/core/Core.php');
+		} elseif (file_exists($this->basePath . '/sapphire/core/Core.php')) {
+			require_once($this->basePath . '/sapphire/core/Core.php');
+		} else {
+			throw new \LogicException("No framework/core/Core.php or sapphire/core/Core.php included in project.  Perhaps $this->basePath is not a SilverStripe project?");
+		}
+
+		// Connect to database
+		require_once('model/DB.php');
+
+		if ($databaseConfig) {
+			DB::connect($databaseConfig);
+		} else {
+			throw new \LogicException("No \$databaseConfig found");
+		}
+	}
+
+	function getDatabase() {
+		$this->connect();
+
+		if(method_exists('DB', 'get_conn')) {
+			return DB::get_conn();
+		} else {
+			return DB::getConn();
+		}
+	}
+
+	/**
+	 * Get a list of tables from the database
+	 */
+	function getTables() {
+		$this->connect();
+
+		if(method_exists('DB', 'table_list')) {
+			return DB::table_list();
+		} else {
+			return DB::tableList();
+		}
+	}
+
+	/**
+	 * Get a list of tables from the database
+	 */
+	function getFieldsForTable($tableName) {
+		$this->connect();
+
+		if(method_exists('DB', 'field_list')) {
+			return DB::field_list($tableName);
+		} else {
+			return DB::fieldList($tableName);
+		}
+	}
+
+	/**
+	 * Save the named table to the given table write
+	 */
+	function saveTable($tableName, TableWriter $writer) {
+		$query = $this->getDatabase()->query("SELECT * FROM \"$tableName\"");
+
+		foreach ($query as $record) {
+			$writer->writeRecord($record);
+		}
+
+		$writer->finish();
+	}
+
+	/**
+	 * Save the named table to the given table write
+	 */
+	function loadTable($tableName, TableReader $reader) {
+		$this->getDatabase()->clearTable($tableName);
+
+		$fields = $this->getFieldsForTable($tableName);
+
+		foreach($reader as $record) {
+			foreach ($record as $k => $v) {
+				if (!isset($fields[$k])) {
+					unset($record[$k]);
+				}
+			}
+			// TODO: Batch records
+			$manipulation = [
+				$tableName => [
+					'command' => 'insert',
+					'fields' => $record,
+				],
+			];
+			DB::manipulate($manipulation);
+		}
+	}
+}

--- a/src/DataExtractor/TableReader.php
+++ b/src/DataExtractor/TableReader.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\SsPak\DataExtractor;
+
+interface TableReader extends \IteratorAggregate
+{
+	/**
+	 * Return an iterator that returns each record of the table reader as a map.
+	 * @return Iterator
+	 */
+	function getIterator();
+
+	/**
+	 * Return the names of the the columns in this table
+	 * @return array The column names
+	 */
+	function getColumns();
+}

--- a/src/DataExtractor/TableWriter.php
+++ b/src/DataExtractor/TableWriter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\SsPak\DataExtractor;
+
+interface TableWriter
+{
+	/**
+	 * Start writing, declaring the columns that will be provided.
+	 * Must be called before writeRecord()
+	 * @param array $columns The columns to be provided as keys in writeRecord() calls
+	 */
+	function start($columns);
+
+	/**
+	 * Write a single record.
+	 * @param array $record A map of column => value data
+	 */
+	function writeRecord($record);
+
+	/**
+	 * Finish writing.
+	 * writeRecord() must not be called after this
+	 */
+	function finish();
+}

--- a/tests/DataExtractor/CsvTableReaderTest.php
+++ b/tests/DataExtractor/CsvTableReaderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use SilverStripe\SsPak\DataExtractor\CsvTableReader;
+
+class CsvTableReaderTest extends PHPUnit_Framework_TestCase
+{
+	function testCsvReading() {
+
+		$csv = new CsvTableReader(__DIR__ . '/fixture/input.csv');
+		$this->assertEquals(['Col1', 'Col2', 'Col3'], $csv->getColumns());
+
+		$extractedData = [];
+		foreach($csv as $record) {
+			$extractedData[] = $record;
+		}
+
+		$this->assertEquals(
+			[
+				[ 'Col1' => 'One', 'Col2' => 2, 'Col3' => 'Three' ],
+				[ 'Col1' => 'Hello, Sam', 'Col2' => 5, 'Col3' => "Nice to meet you\nWhat is your name?" ]
+			],
+			$extractedData
+		);
+
+	}
+}

--- a/tests/DataExtractor/CsvTableWriterTest.php
+++ b/tests/DataExtractor/CsvTableWriterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use SilverStripe\SsPak\DataExtractor\CsvTableWriter;
+
+class CsvTableWriterTest extends PHPUnit_Framework_TestCase
+{
+	function testCsvReading() {
+
+		if (file_exists('/tmp/output.csv')) {
+			unlink('/tmp/output.csv');
+		}
+
+		$csv = new CsvTableWriter('/tmp/output.csv');
+
+		$csv->start(['Col1', 'Col2', 'Col3']);
+		$csv->writeRecord([ 'Col1' => 'One', 'Col2' => 2, 'Col3' => 'Three' ]);
+		$csv->writeRecord([ 'Col1' => 'Hello, Sam', 'Col2' => 5, 'Col3' => "Nice to meet you\nWhat is your name?" ]);
+		$csv->finish();
+
+		$csvContent = file_get_contents('/tmp/output.csv');
+		unlink('/tmp/output.csv');
+
+		$fixture = file_get_contents(__DIR__ . '/fixture/input.csv');
+
+		$this->assertEquals($fixture, $csvContent);
+	}
+
+	function testNoStartCall() {
+
+		if (file_exists('/tmp/output.csv')) {
+			unlink('/tmp/output.csv');
+		}
+
+		$csv = new CsvTableWriter('/tmp/output.csv');
+
+		$csv->writeRecord([ 'Col1' => 'One', 'Col2' => 2, 'Col3' => 'Three' ]);
+		$csv->writeRecord([ 'Col1' => 'Hello, Sam', 'Col2' => 5, 'Col3' => "Nice to meet you\nWhat is your name?" ]);
+		$csv->finish();
+
+		$csvContent = file_get_contents('/tmp/output.csv');
+		unlink('/tmp/output.csv');
+
+		$fixture = file_get_contents(__DIR__ . '/fixture/input.csv');
+
+		$this->assertEquals($fixture, $csvContent);
+	}
+
+}

--- a/tests/DataExtractor/fixture/input.csv
+++ b/tests/DataExtractor/fixture/input.csv
@@ -1,0 +1,4 @@
+Col1,Col2,Col3
+One,2,Three
+"Hello, Sam",5,"Nice to meet you
+What is your name?"


### PR DESCRIPTION
This introduces 3 new commands:

 - loadcsv
 - savecsv
 - listtables

The CSV commands will persist data as a folder of CSV files, 1 per
table. This can be useful for transferring data across different
database backends.