### PR TITLE
Add proposed changes to fix bug #45

### DIFF
--- a/src/Executor.php
+++ b/src/Executor.php
@@ -145,7 +145,7 @@ class Process {
 
 		if($options['throwException'] && $result['return'] != 0)	{
 			throw new Exception("Command: $command\nExecution failed: returned {$result['return']}.\n"
-				. (empty($result['output']) ? "" : "Output:\n{$result['output']}"));
+				. (empty($result['error']) ? "" : "Output:\n{$result['error']}"));
 		}
 
 		return $result;


### PR DESCRIPTION
Changed the message used by the thrown exception to "error" rather then "output" as mentioned in issue #45