### PR TITLE
Allow BASE_URL to be set outside SSPAK

### DIFF
--- a/src/sspak-sniffer.php
+++ b/src/sspak-sniffer.php
@@ -17,7 +17,9 @@ if($basePath[0] != '/') $basePath = getcwd() . '/' . $basePath;
 
 // SilverStripe bootstrap
 define('BASE_PATH', $basePath);
-define('BASE_URL', '/');
+if (!defined('BASE_URL')) {
+	define('BASE_URL', '/');
+}
 $_SERVER['HTTP_HOST'] = 'localhost';
 chdir(BASE_PATH);
 


### PR DESCRIPTION
Be safe around the BASE_URL constant, allow setting it e.g. in the _ss_environment.php file.