### PR TITLE
ENHANCEMENT Support global composer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-SSPak
-=====
+# SSPak
 
 [![Build Status](http://img.shields.io/travis/silverstripe/sspak.svg?style=flat-square)](https://travis-ci.org/silverstripe/sspak)
 [![Code Quality](http://img.shields.io/scrutinizer/g/silverstripe/sspak.svg?style=flat-square)](https://scrutinizer-ci.com/g/silverstripe/sspak)
@@ -7,8 +6,7 @@ SSPak
 SSPak is a SilverStripe tool for managing database and assets content, for back-up, restoration, or transfer between
 environments.
 
-The file format
----------------
+## The file format
 
 An sspak file is either a Phar (executable) file or a Tar (non-executable) file, containing the following files at the top level:
 
@@ -16,112 +14,114 @@ An sspak file is either a Phar (executable) file or a Tar (non-executable) file,
  * **assets.tar.gz:** A gzipped tar file containing all assets.  The root directory within the tar file must be called "assets".
  * **git-remote:** A text file of the following form:
 
-        remote = (url)
-        branch = (name)
-        sha = (sha-hash)
+	remote = (url)
+	branch = (name)
+	sha = (sha-hash)
 
 By convention, the file should have the extension `.sspak` for non-executable versions, and `.sspak.phar` for executable versions.
 
-Installation
-------------
+## Installation
 
-You can run the installation script one of two ways.  If you have CURL, run this command (everything except for the `$>` part):
+You can run the installation script one of two ways.
 
-    $> curl -sS https://silverstripe.github.io/sspak/install | php -- /usr/local/bin
+### cURL
+
+If you have cURL, run this command (everything except for the `$>` part):
+
+	$> curl -sS https://silverstripe.github.io/sspak/install | php -- /usr/local/bin
 
 The final argument is the directory that the script will be loaded into.  If omitted, the script will be installed into the current directory.  If you don't have permission to write to the directory, "sudo" will be used to escalate permissions.
 
 For example, this would also work:
 
-    $> cd /usr/local/bin
-    $> curl -sS https://silverstripe.github.io/sspak/install | sudo php
+	$> cd /usr/local/bin
+	$> curl -sS https://silverstripe.github.io/sspak/install | sudo php
+
+### Manually
 
 If you prefer not to use the installer, you can download the script and copy it to your executable path as follows:
 
-    $> wget https://silverstripe.github.io/sspak/sspak.phar
-    $> chmod +x sspak.phar
-    $> sudo mv sspak.phar /usr/local/bin/sspak
+	$> wget https://silverstripe.github.io/sspak/sspak.phar
+	$> chmod +x sspak.phar
+	$> sudo mv sspak.phar /usr/local/bin/sspak
 
-Common Issues
--------------
 
-    Creating archive disabled by the php.ini setting phar.readonly
+## Common Issues
+
+	Creating archive disabled by the php.ini setting phar.readonly
 
 Set your phar.readonly setting to false in your php.ini (and php-cli.ini) files.
 
 
-Use
----
+##  Use
 
 All sspak commands take the following general form.
 
-    $> sspak (command) (from) (to)
+	$> sspak (command) (from) (to)
 
 Create an sspak file and save to /tmp:
 
-    $> sspak save /var/www /tmp/site.sspak
+	$> sspak save /var/www /tmp/site.sspak
 
 Create an sspak file based on a remote site:
 
-    $> sspak save me@prodserver:/var/www prod-site.sspak
+	$> sspak save me@prodserver:/var/www prod-site.sspak
 
 Create an sspak file based on a remote site using a specific private key to connect:
 
-    $> sspak save --identity=prodserver.key me@prodserver:/var/www prod-site.sspak
+	$> sspak save --identity=prodserver.key me@prodserver:/var/www prod-site.sspak
 
 Create an executable sspak file by adding a phar extension:
 
-    $> sspak save me@prodserver:/var/www prod-site.sspak.phar
+	$> sspak save me@prodserver:/var/www prod-site.sspak.phar
 
 Create an sspak from existing files:
 
-    $> sspak saveexisting --db=/path/to/database.sql --assets=/path/to/assets
+	$> sspak saveexisting --db=/path/to/database.sql --assets=/path/to/assets
 
 Extract files from an existing sspak into the specified directory:
 
-    $> sspak extract /tmp/site.sspak /destination/path
+	$> sspak extract /tmp/site.sspak /destination/path
 
 Load an sspak file into a local instance:
 
-    $> sspak load prod-site.sspak ~/Sites/devsite
+	$> sspak load prod-site.sspak ~/Sites/devsite
 
 Load an sspak file into a local instance, dropping the existing DB first (mysql only):
 
-    $> sspak load prod-site.sspak ~/Sites/devsite --drop-db
+	$> sspak load prod-site.sspak ~/Sites/devsite --drop-db
 
 Load an sspak file into a remote instance using a specific private key to connect:
 
-    $> sspak save --identity=backupserver.key prod-site.sspak me@backupserver:/var/www
+	$> sspak save --identity=backupserver.key prod-site.sspak me@backupserver:/var/www
 
 Transfer in one step: *(not implemented yet)*
 
-    $> sspak transfer me@prodserver:/var/www ~/Sites/devsite
+	$> sspak transfer me@prodserver:/var/www ~/Sites/devsite
 
 Sudo as www-data to perform the actions
 
-    $> sspak save --sudo=www-data me@prodserver:/var/www prod-site.sspak
-    $> sspak load --sudo=www1 prod-site.sspak ~/Sites/devsite
-    $> sspak transfer --from-sudo=www-data --to-sudo=www1 me@prodserver:/var/www ~/Sites/devsite
+	$> sspak save --sudo=www-data me@prodserver:/var/www prod-site.sspak
+	$> sspak load --sudo=www1 prod-site.sspak ~/Sites/devsite
+	$> sspak transfer --from-sudo=www-data --to-sudo=www1 me@prodserver:/var/www ~/Sites/devsite
 
 Save only the database:
 
-    $> sspak save --db me@prodserver:/var/www dev.sspak
+	$> sspak save --db me@prodserver:/var/www dev.sspak
 
 Load only the assets:
 
-    $> sspak load --assets dev.sspak ~/Sites/devsite
+	$> sspak load --assets dev.sspak ~/Sites/devsite
 
 Install a new site from an sspak (needs to contain a git-remote):
 
-    $> sspak install newsite.sspak ~/Sites/newsite
+	$> sspak install newsite.sspak ~/Sites/newsite
 
-Caveats
--------
+## Caveats
 
 If you don't have PKI passwordless log-in into remote servers, you will be asked for your log-in a few times.
 
-How it works
-------------
+## How it works
 
 sspak relies on the SilverStripe executable code to determine database credentials.  It does this by using a small script, sspak-sniffer.php, which it uploads to the /tmp folder of any remote servers.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ By convention, the file should have the extension `.sspak` for non-executable ve
 
 ## Installation
 
-You can run the installation script one of two ways.
+You can run the installation script one of three ways.
+
+### Composer
+
+You can install this package globally with Composer (ensure your composer bin is in your system path):
+
+    $> composer global require silverstripe/sspak
 
 ### cURL
 

--- a/bin-composer/sspak
+++ b/bin-composer/sspak
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Run SSPak with composer!
+ */
+define('PACKAGE_ROOT', dirname(__FILE__) . '/../');
+define('SSPAK_COMPOSER_INSTALL', true);
+require_once PACKAGE_ROOT . 'bin/sspak';

--- a/bin/sspak
+++ b/bin/sspak
@@ -6,7 +6,11 @@ if (!defined('PACKAGE_ROOT')) {
 	define('PACKAGE_ROOT', dirname(dirname(__FILE__)) . '/');
 }
 
-require_once PACKAGE_ROOT . 'vendor/autoload.php';
+// We only need composer once
+if (!defined('SSPAK_COMPOSER_INSTALL') || !SSPAK_COMPOSER_INSTALL) {
+	require_once PACKAGE_ROOT . 'vendor/autoload.php';
+}
+
 require_once PACKAGE_ROOT . 'src/Args.php';
 require_once PACKAGE_ROOT . 'src/Executor.php';
 require_once PACKAGE_ROOT . 'src/SSPak.php';

--- a/bin/sspak
+++ b/bin/sspak
@@ -2,16 +2,17 @@
 <?php
 
 // Root from which to refer to src/
-if(!defined('PACKAGE_ROOT')) define('PACKAGE_ROOT', dirname(dirname(__FILE__)) . '/');
+if (!defined('PACKAGE_ROOT')) {
+	define('PACKAGE_ROOT', dirname(dirname(__FILE__)) . '/');
+}
 
-require_once(PACKAGE_ROOT . 'src/Args.php');
-require_once(PACKAGE_ROOT . 'src/Executor.php');
-require_once(PACKAGE_ROOT . 'src/SSPak.php');
-require_once(PACKAGE_ROOT . 'src/FilesystemEntity.php');
-require_once(PACKAGE_ROOT . 'src/SSPakFile.php');
-require_once(PACKAGE_ROOT . 'src/Webroot.php');
-
-require_once(PACKAGE_ROOT . 'vendor/autoload.php');
+require_once PACKAGE_ROOT . 'vendor/autoload.php';
+require_once PACKAGE_ROOT . 'src/Args.php';
+require_once PACKAGE_ROOT . 'src/Executor.php';
+require_once PACKAGE_ROOT . 'src/SSPak.php';
+require_once PACKAGE_ROOT . 'src/FilesystemEntity.php';
+require_once PACKAGE_ROOT . 'src/SSPakFile.php';
+require_once PACKAGE_ROOT . 'src/Webroot.php';
 
 $argObj = new Args($_SERVER['argv']);
 /*

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 	"autoload": {
 		"classmap": [ "src/" ]
 	},
+	"bin": ["bin-composer/sspak"],
 	"require": {},
 	"require-dev": {
 		"phpunit/phpunit": "^3.7"


### PR DESCRIPTION
* Adds a new bin location for composer so we can use `sspak` still as the bin filename
* Rejigged readme to use `#` for titles, and added installation example with composer
* Tweaked a couple of constant values to ensure composer-compatible `sspak` works with B/C over original

Resolves #21