### PR TITLE
FIX: docs on creating an sspak from existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Create an executable sspak file by adding a phar extension:
 
 Create an sspak from existing files:
 
-	$> sspak saveexisting --db=/path/to/database.sql --assets=/path/to/assets
+	$> sspak saveexisting --db=/path/to/database.sql --assets=/path/to/assets /tmp/site.sspak
 
 Extract files from an existing sspak into the specified directory:
 


### PR DESCRIPTION
The docs leave off the location command for building an sspak from an existing .sql or assets folder. This trips up users not familiar with the format of the commands.