### PR TITLE
Enable support for TMP folder override via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Install a new site from an sspak (needs to contain a git-remote):
 
 	$> sspak install newsite.sspak ~/Sites/newsite
 
+Save all while using a custom TMP folder (make sure the folder exists and is writable):
+
+	$> TMPDIR="/tmp/my_custom_tmp" sspak save /var/www /tmp/site.sspak
+
 ## Caveats
 
 If you don't have PKI passwordless log-in into remote servers, you will be asked for your log-in a few times.

--- a/src/SSPak.php
+++ b/src/SSPak.php
@@ -273,7 +273,7 @@ EOM;
 		$details = $webroot->sniff();
 
 		// Create a build folder for the sspak file
-		$buildFolder = "/tmp/sspak-" . rand(100000,999999);
+		$buildFolder = sprintf("%s/sspak-%d", sys_get_temp_dir(), rand(100000,999999));
 		$webroot->exec(array('mkdir', $buildFolder));
 
 		$dbFile = "$buildFolder/database.sql.gz";


### PR DESCRIPTION
As the title mentions, replace hardcoded `/tmp` path with `sys_get_temp_dir` call to be able to provide custom folder as an env. variable.

Rationale: sometimes the /tmp folder is on a separate drive with less disk space than required, and is the only obstacle in the way of creating larger sspak files.